### PR TITLE
Update linter and webpack configs

### DIFF
--- a/client/.eslintrc.json
+++ b/client/.eslintrc.json
@@ -3,11 +3,7 @@
         "es2021": true,
         "node": true
     },
-    "extends": [
-        "eslint:recommended",
-        "plugin:@typescript-eslint/recommended",
-        "prettier"
-    ],
+    "extends": ["eslint:recommended", "plugin:@typescript-eslint/recommended", "prettier"],
     "parser": "@typescript-eslint/parser",
     "parserOptions": {
         "ecmaVersion": "latest",
@@ -15,7 +11,7 @@
     },
     "plugins": ["@typescript-eslint"],
     "rules": {
-        "linebreak-style": ["error", "unix"],
+        "linebreak-style": "off",
         "quotes": ["error", "single", { "avoidEscape": true }],
         "semi": "off",
         "no-var": "error",
@@ -33,49 +29,44 @@
         "camelcase": "off",
         "require-await": "error",
         "@typescript-eslint/no-dupe-class-members": ["error"],
-        "@typescript-eslint/explicit-member-accessibility": [
-            "error",
-            { "accessibility": "explicit" }
-        ],
+        "@typescript-eslint/explicit-member-accessibility": ["error", { "accessibility": "explicit" }],
         "@typescript-eslint/explicit-module-boundary-types": ["error"],
-        "@typescript-eslint/no-inferrable-types": [
-            "error",
-            { "ignoreParameters": true }
-        ],
+        "@typescript-eslint/no-inferrable-types": ["error", { "ignoreParameters": true }],
         "@typescript-eslint/naming-convention": [
-          "error",
-          {
-            "selector": "default",
-            "format": ["camelCase"]
-          },
-          {
-            "selector": "variable",
-            "format": ["strictCamelCase"]
-          },
-          {
-            "selector": "parameter",
-            "format": ["strictCamelCase"],
-            "leadingUnderscore": "allow"
-          },
-          {
-            "selector": "classProperty",
-            "modifiers": ["private"],
-            "format": ["strictCamelCase"],
-            "leadingUnderscore": "require"
-          },
-          {
-            "selector": "classMethod",
-            "modifiers": ["private"],
-            "format": null
-          },
-          {
-            "selector": "typeLike",
-            "format": ["PascalCase"]
-          },
-          {
-              "selector": "enumMember",
-              "format": ["PascalCase"]
-          }
-        ]
+            "error",
+            {
+                "selector": "default",
+                "format": ["camelCase"]
+            },
+            {
+                "selector": "variable",
+                "format": ["strictCamelCase"]
+            },
+            {
+                "selector": "parameter",
+                "format": ["strictCamelCase"],
+                "leadingUnderscore": "allow"
+            },
+            {
+                "selector": "classProperty",
+                "modifiers": ["private"],
+                "format": ["strictCamelCase"],
+                "leadingUnderscore": "require"
+            },
+            {
+                "selector": "classMethod",
+                "modifiers": ["private"],
+                "format": null
+            },
+            {
+                "selector": "typeLike",
+                "format": ["PascalCase"]
+            },
+            {
+                "selector": "enumMember",
+                "format": ["PascalCase"]
+            }
+        ],
+        "@typescript-eslint/no-non-null-assertion": "off"
     }
 }

--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -43,4 +43,7 @@ module.exports = {
         },
         port: 3000,
     },
+    performance: {
+        hints: false,
+    },
 };

--- a/server/.eslintrc.json
+++ b/server/.eslintrc.json
@@ -3,11 +3,7 @@
         "es2021": true,
         "node": true
     },
-    "extends": [
-        "eslint:recommended",
-        "plugin:@typescript-eslint/recommended",
-        "prettier"
-    ],
+    "extends": ["eslint:recommended", "plugin:@typescript-eslint/recommended", "prettier"],
     "parser": "@typescript-eslint/parser",
     "parserOptions": {
         "ecmaVersion": "latest",
@@ -15,7 +11,7 @@
     },
     "plugins": ["@typescript-eslint"],
     "rules": {
-        "linebreak-style": ["error", "unix"],
+        "linebreak-style": "off",
         "quotes": ["error", "single", { "avoidEscape": true }],
         "semi": "off",
         "no-var": "error",
@@ -33,49 +29,44 @@
         "camelcase": "off",
         "require-await": "error",
         "@typescript-eslint/no-dupe-class-members": ["error"],
-        "@typescript-eslint/explicit-member-accessibility": [
-            "error",
-            { "accessibility": "explicit" }
-        ],
+        "@typescript-eslint/explicit-member-accessibility": ["error", { "accessibility": "explicit" }],
         "@typescript-eslint/explicit-module-boundary-types": ["error"],
-        "@typescript-eslint/no-inferrable-types": [
-            "error",
-            { "ignoreParameters": true }
-        ],
+        "@typescript-eslint/no-inferrable-types": ["error", { "ignoreParameters": true }],
         "@typescript-eslint/naming-convention": [
-          "error",
-          {
-            "selector": "default",
-            "format": ["camelCase"]
-          },
-          {
-            "selector": "variable",
-            "format": ["strictCamelCase"]
-          },
-          {
-            "selector": "parameter",
-            "format": ["strictCamelCase"],
-            "leadingUnderscore": "allow"
-          },
-          {
-            "selector": "classProperty",
-            "modifiers": ["private"],
-            "format": ["strictCamelCase"],
-            "leadingUnderscore": "require"
-          },
-          {
-            "selector": "classMethod",
-            "modifiers": ["private"],
-            "format": null
-          },
-          {
-            "selector": "typeLike",
-            "format": ["PascalCase"]
-          },
-          {
-              "selector": "enumMember",
-              "format": ["PascalCase"]
-          }
-        ]
+            "error",
+            {
+                "selector": "default",
+                "format": ["camelCase"]
+            },
+            {
+                "selector": "variable",
+                "format": ["strictCamelCase"]
+            },
+            {
+                "selector": "parameter",
+                "format": ["strictCamelCase"],
+                "leadingUnderscore": "allow"
+            },
+            {
+                "selector": "classProperty",
+                "modifiers": ["private"],
+                "format": ["strictCamelCase"],
+                "leadingUnderscore": "require"
+            },
+            {
+                "selector": "classMethod",
+                "modifiers": ["private"],
+                "format": null
+            },
+            {
+                "selector": "typeLike",
+                "format": ["PascalCase"]
+            },
+            {
+                "selector": "enumMember",
+                "format": ["PascalCase"]
+            }
+        ],
+        "@typescript-eslint/no-non-null-assertion": "off"
     }
 }


### PR DESCRIPTION
* disable the eslint linebreak style - git handles this
* disable the eslint/typescript no non null assertion - this is useful to use and is needed to simplify some runtime code
* disable performance warnings for webpack - phaser is a big library and can't really be compartmentalised easily, and any performance issues can be checked later in development

also prettier did a reformat